### PR TITLE
fix: Ubuntu setup script dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ On login the OS may hang. Below are the instructions I followed to remedy the is
 Runs this installation script to install my Ubuntu 20.04 application setup:
 
 ```shell
-sh -c "$(curl -fsSL https://raw.github.com/jthegedus/dotfiles/master/scripts/setup-ubuntu.bash)"
+bash -c "$(curl -fsSL https://raw.github.com/jthegedus/dotfiles/master/scripts/setup-ubuntu.bash)"
 # wget alternative?
 ```
 

--- a/scripts/setup-ubuntu.bash
+++ b/scripts/setup-ubuntu.bash
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-# shellcheck source=./utils.bash
-source "$(dirname "$0")/utils.bash"
-
 # install from apt
 sudo apt install git curl tar apt-transport-https gnome-tweaks -y
 
@@ -62,5 +59,6 @@ Exec=/home/egdoc/.local/bin/firefox-dev --private-window %u
 EOL
     chmod +x "${firefox_developer_desktop_entry_path}"
 else
-    log_info "Firefox Developer Edition is already installed."
+    # cannot replace with utils.bash log_info as it will break remote file pull and execute.
+    printf "ℹ️  Firefox Developer Edition is already installed.\\n"
 fi


### PR DESCRIPTION
- [x] update install script docs to use `bash` over `sh` as `sh` is usually a different shell aliased to `sh`.
- [x] remove dependencies of `setup-ubuntu.bash` script so it can be pulled and executed via `curl` as a single script