### PR TITLE
feat: add navi and homebrew core on linux

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -176,5 +176,8 @@ source_if_exists "$HOME/.aliases"
 printf "🚀  Load Starship shell prompt\\n"
 eval "$(starship init zsh)"
 
+printf "%s\\n" "Load Navi"
+source <(navi widget zsh)
+
 # printf "\\n🏞  Environment Variables: \\n\\n"
 # printenv

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -177,6 +177,7 @@ printf "🚀  Load Starship shell prompt\\n"
 eval "$(starship init zsh)"
 
 printf "%s\\n" "Load Navi"
+# shellcheck disable=SC1090
 source <(navi widget zsh)
 
 # printf "\\n🏞  Environment Variables: \\n\\n"

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -76,18 +76,18 @@ fpath=($HOME/.asdf/completions $fpath)
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(
-  asdf
-  docker
-  fzf
-  # gcloud
-  git
-  golang
-  node
-  npm
-  npx
-  python
-  pip
-  zsh-syntax-highlighting
+	asdf
+	docker
+	fzf
+	# gcloud
+	git
+	golang
+	node
+	npm
+	npx
+	python
+	pip
+	zsh-syntax-highlighting
 )
 
 # User configuration
@@ -99,9 +99,9 @@ plugins=(
 
 # Preferred editor for local and remote sessions
 if [[ -n $SSH_CONNECTION ]]; then
-  export EDITOR='code'
+	export EDITOR='code'
 else
-  export EDITOR='nano'
+	export EDITOR='nano'
 fi
 
 # Compilation flags
@@ -131,25 +131,25 @@ HISTFILE=~/.zsh_history
 
 # add resource to path (once and only once)
 add_path_to_global_path() {
-  local TO_ADD="$1"
+	local TO_ADD="$1"
 
-  # if in $PATH, remove
-  # replace all occurrences - ${parameter//pattern/string}
-  [[ ":$PATH:" == *":${TO_ADD}:"* ]] && PATH="${PATH//$TO_ADD:/}"
-  # add to PATH
-  PATH="${TO_ADD}:$PATH"
-  printf "✅  added to global path:\\t%s\\n" "$1"
+	# if in $PATH, remove
+	# replace all occurrences - ${parameter//pattern/string}
+	[[ ":$PATH:" == *":${TO_ADD}:"* ]] && PATH="${PATH//$TO_ADD:/}"
+	# add to PATH
+	PATH="${TO_ADD}:$PATH"
+	printf "✅  added to global path:\\t%s\\n" "$1"
 }
 
 # Will source the provided resource if the resource exists
 source_if_exists() {
-  if [ -f "$1" ]; then
-    # shellcheck disable=SC1090
-    . "$1"
-    printf "✅  Sourced:\\t%s\\n" "$1"
-  else
-    printf "🚨  Failed to source: %s\\n" "$1"
-  fi
+	if [ -f "$1" ]; then
+		# shellcheck disable=SC1090
+		. "$1"
+		printf "✅  Sourced:\\t%s\\n" "$1"
+	else
+		printf "🚨  Failed to source: %s\\n" "$1"
+	fi
 }
 
 ### oh-my-zsh
@@ -172,13 +172,18 @@ source_if_exists "$HOME/.aliases"
 # WIP. See here for now - https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line
 # add_path_to_global_path "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
 
-### https://starship.rs
-printf "🚀  Load Starship shell prompt\\n"
-eval "$(starship init zsh)"
+# Homebrew on Linux
+[ "$(uname -s)" = "Linux" ] &&
+	printf "%s\\n" "🍺  Load Homebrew on Linux" &&
+	eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
-printf "%s\\n" "Load Navi"
+printf "%s\\n" "🦋  Load Navi"
 # shellcheck disable=SC1090
 source <(navi widget zsh)
+
+### https://starship.rs
+printf "%s\\n" "🚀  Load Starship shell prompt"
+eval "$(starship init zsh)"
 
 # printf "\\n🏞  Environment Variables: \\n\\n"
 # printenv

--- a/scripts/setup-shell.bash
+++ b/scripts/setup-shell.bash
@@ -5,6 +5,20 @@ set -eo pipefail
 # shellcheck source=./utils.bash
 source "$(dirname "$0")/utils.bash"
 
+# Homebrew
+if is_installed "brew"; then
+	log_success "Homebrew already installed"
+else
+	if [ -n "$LINUX" ]; then
+		sudo apt-get install build-essential curl file git -y
+		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+	elif [ -n "$MACOS" ]; then
+		xcode-select --install
+		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+	fi
+	log_success "Brew installed successfully"
+fi
+
 # Dependencies
 log_info "Installing dependencies"
 if [ -n "$LINUX" ]; then
@@ -15,8 +29,6 @@ if [ -n "$LINUX" ]; then
 		libncurses-dev libssl-dev libyaml-dev \
 		libxslt-dev libffi-dev libtool unixodbc-dev -y
 elif [ -n "$MACOS" ]; then
-	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-	xcode-select --install
 	brew install curl unzip
 	brew install \
 		coreutils automake autoconf openssl \
@@ -100,11 +112,13 @@ else
 fi
 
 # navi - https://github.com/denisidoro/navi
-if [ -n "$LINUX" ]; then
-	echo "TODO: install navi on Linux"
-elif [ -n "$MACOS" ]; then
+if is_installed "navi"; then
+	log_success "Navi already installed"
+else
 	brew install navi
+	log_success "Navi installed successfully"
 fi
+
 # dynamically symlink all config/dotfiles to home directory
 # shellcheck source=./symlink-dotfiles.bash
 source "$(dirname "$0")/symlink-dotfiles.bash"

--- a/scripts/setup-shell.bash
+++ b/scripts/setup-shell.bash
@@ -13,16 +13,14 @@ if [ -n "$LINUX" ]; then
 	sudo apt install \
 		automake autoconf libreadline-dev \
 		libncurses-dev libssl-dev libyaml-dev \
-		libxslt-dev libffi-dev libtool unixodbc-dev \
-		unzip -y
+		libxslt-dev libffi-dev libtool unixodbc-dev -y
 elif [ -n "$MACOS" ]; then
 	/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	xcode-select --install
 	brew install curl unzip
 	brew install \
 		coreutils automake autoconf openssl \
-		libyaml readline libxslt libtool unixodbc \
-		unzip curl
+		libyaml readline libxslt libtool unixodbc
 else
 	log_failure_and_exit "🚨  Script only supports macOS and Ubuntu"
 fi
@@ -102,7 +100,11 @@ else
 fi
 
 # navi - https://github.com/denisidoro/navi
-
+if [ -n "$LINUX" ]; then
+	echo "TODO: install navi on Linux"
+elif [ -n "$MACOS" ]; then
+	brew install navi
+fi
 # dynamically symlink all config/dotfiles to home directory
 # shellcheck source=./symlink-dotfiles.bash
 source "$(dirname "$0")/symlink-dotfiles.bash"


### PR DESCRIPTION
Add [Navi](https://github.com/denisidoro/navi/).

- [x] chore: cleanup duplicate dependency installation
- [x] feat: install navi via brew for macos
- [x] ~TODO: navi on linux. Annoyingly we're going to need Homebrew on Linux or to install from binary. I have not been able to get the Navi Bash install script method to work.~ Navi via Homebrew on Linux!

Closes #17 