### PR TITLE
fix: revert linuxbrew usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ and all system dependencies required by each of the above tools.
     cd ~ && git clone https://github.com/jthegedus/dotfiles ~/projects/dotfiles
     ```
 
-2. run the `setup-shell.bash` script
+2. run the `setup-shell.bash` script. This script is interactive! (`exit` OMZSH shell once it is default. Then restart your shell.)
 
     ```shell
     ~/projects/dotfiles/scripts/setup-shell.bash

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -171,14 +171,10 @@ source_if_exists "$HOME/.aliases"
 # WIP. See here for now - https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line
 # add_path_to_global_path "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
 
-# Homebrew on Linux
-[ "$(uname -s)" = "Linux" ] &&
-	printf "%s\\n" "🍺  Load Homebrew on Linux" &&
-	eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
-printf "%s\\n" "🦋  Load Navi"
-# shellcheck disable=SC1090
-source <(navi widget zsh)
+[ "$(uname -s)" = "Darwin" ] &&
+	printf "%s\\n" "🦋  Load Navi" &&
+	# shellcheck disable=SC1090
+	source <(navi widget zsh)
 
 ### https://starship.rs
 printf "%s\\n" "🚀  Load Starship shell prompt"

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -171,9 +171,9 @@ source_if_exists "$HOME/.aliases"
 # WIP. See here for now - https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line
 # add_path_to_global_path "/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
 
+# shellcheck disable=SC1090
 [ "$(uname -s)" = "Darwin" ] &&
 	printf "%s\\n" "🦋  Load Navi" &&
-	# shellcheck disable=SC1090
 	source <(navi widget zsh)
 
 ### https://starship.rs

--- a/scripts/setup-shell.bash
+++ b/scripts/setup-shell.bash
@@ -6,17 +6,14 @@ set -eo pipefail
 source "$(dirname "$0")/utils.bash"
 
 # Homebrew
-if is_installed "brew"; then
-	log_success "Homebrew already installed"
-else
-	if [ -n "$LINUX" ]; then
-		sudo apt-get install build-essential curl file git -y
-		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-	elif [ -n "$MACOS" ]; then
+if [ -n "$MACOS" ]; then
+	if is_installed "brew"; then
+		log_success "Homebrew already installed"
+	else
 		xcode-select --install
 		/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+		log_success "Brew installed successfully"
 	fi
-	log_success "Brew installed successfully"
 fi
 
 # Dependencies
@@ -85,13 +82,31 @@ else
 fi
 ############ END: ZSH
 
-# navi		- https://github.com/denisidoro/navi
-# z			- https://github.com/rupa/z
-# starship	- https://starship.rs/
-brew install \
-	navi \
-	z \
-	starship
+# starship theme
+if is_installed starship; then
+	log_success "Starship theme already installed"
+else
+	log_info "Installing Starship theme 🚀"
+	curl -fsSL https://starship.rs/install.sh | bash
+fi
+
+# install z
+if [ -f "${HOME}/z.sh" ]; then
+	log_success "z.sh already installed"
+else
+	log_info "Installing z"
+	wget -P "${HOME}" https://raw.githubusercontent.com/rupa/z/master/z.sh
+fi
+
+# navi - https://github.com/denisidoro/navi
+if [ -n "$MACOS" ]; then
+	if is_installed "navi"; then
+		log_success "Navi already installed"
+	else
+		brew install navi
+		log_success "Navi installed successfully"
+	fi
+fi
 
 # dynamically symlink all config/dotfiles to home directory
 # shellcheck source=./symlink-dotfiles.bash

--- a/scripts/setup-ubuntu.bash
+++ b/scripts/setup-ubuntu.bash
@@ -11,8 +11,8 @@ sudo snap install code --classic
 # Gitkraken
 # Fix Gitkraken snap launcher icon
 sudo snap install gitkraken --classic
-gitkraken_icon_path="Icon=/snap/gitkraken/current/usr/share/gitkraken/gitkraken.png"
-gitkraken_snap_path="/var/lib/snapd/desktop/applications/gitkraken_gitkraken.desktop"
+# gitkraken_icon_path="Icon=/snap/gitkraken/current/usr/share/gitkraken/gitkraken.png"
+# gitkraken_snap_path="/var/lib/snapd/desktop/applications/gitkraken_gitkraken.desktop"
 # sudo printf "\n%s" "${gitkraken_icon_path}" >>"${gitkraken_snap_path}"
 
 # Barrier (cross-platform keyboard-mouse network sharing)


### PR DESCRIPTION
Revert Linuxbrew usage.

- install Homebrew on macOS system only
- only install navi on macOS (brew is standard install method)