### PR TITLE
chore: cleanup by rm java, unused npm modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Items installed in the following scripts include:
 
 - shell: [`zsh`](https://github.com/ohmyzsh/ohmyzsh/wiki/Installing-ZSH) · [`oh-my-zsh`](https://github.com/ohmyzsh/ohmyzsh) · [`powerline fonts`](https://github.com/powerline/fonts) · [`starship cross-shell theme`](https://starship.rs/)
 - tools: [`asdf`](https://github.com/asdf-vm/asdf) · [`shellcheck`](https://github.com/koalaman/shellcheck) · [`navi`](https://github.com/denisidoro/navi) · [`z`](https://github.com/rupa/z)
-- tools with asdf: [`nodejs`](https://github.com/asdf-vm/asdf-nodejs) · [`deno`](https://github.com/asdf-community/asdf-deno) · [`firebase`](https://github.com/jthegedus/asdf-firebase) · [`gcloud`](https://github.com/jthegedus/asdf-gcloud) · [`hadolint`](https://github.com/looztra/asdf-hadolint) · [`java`](https://github.com/halcyon/asdf-java) · [`python`](https://github.com/danhper/asdf-python) · [`shellcheck`](https://github.com/luizm/asdf-shellcheck) · [`terraform`](https://github.com/Banno/asdf-hashicorp)
+- tools with asdf: [`nodejs`](https://github.com/asdf-vm/asdf-nodejs) · [`deno`](https://github.com/asdf-community/asdf-deno) · [`firebase`](https://github.com/jthegedus/asdf-firebase) · [`gcloud`](https://github.com/jthegedus/asdf-gcloud) · [`hadolint`](https://github.com/looztra/asdf-hadolint) · [`python`](https://github.com/danhper/asdf-python) · [`shellcheck`](https://github.com/luizm/asdf-shellcheck) · [`terraform`](https://github.com/Banno/asdf-hashicorp)
 
 and all system dependencies required by each of the above tools.
 
@@ -126,7 +126,9 @@ and all system dependencies required by each of the above tools.
     ~/projects/dotfiles/scripts/setup-devtools.bash
     ```
 
-5. run the `setup-devtools.bash` script again (this is because `asdf` requires a shell restart to take effect. The script accounts for re-running)
+5. restart your shell as required by `asdf`
+
+6. run the `setup-devtools.bash` script again (The script accounts for re-running)
 
     ```shell
     ~/projects/dotfiles/scripts/setup-devtools.bash
@@ -187,9 +189,9 @@ From the Ubuntu Store (snaps):
 
 Add VSCode to macOS path: https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line
 
-[My vscode sync-settings can be found here](https://gist.github.com/jthegedus/a692812095d3bf7efa132c5a1bfe8d71). Choice extensions include:
+Choice extensions include:
 
-- [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync): Store your config in the cloud making multi-machine and reinstallations a breeze!
+- Settings Sync: [Now built into VSCode](https://code.visualstudio.com/docs/editor/settings-sync)!
 - [shellcheck](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck): static analysis your `.sh` scripts. Requires [shellcheck itself](https://github.com/koalaman/shellcheck#shellcheck---a-shell-script-static-analysis-tool).
 - [shell format](https://github.com/foxundermoon/vs-shell-format): formats `.sh`, `.bash`, `Dockerfiles`, ignore files, amongst others.
 

--- a/config/initial-asdf-plugins.txt
+++ b/config/initial-asdf-plugins.txt
@@ -1,7 +1,6 @@
 firebase latest
 golang latest
 hadolint v1.17.5
-java adoptopenjdk-11.0.6+10.1
 nodejs 14.8.0
 python latest
 shellcheck latest

--- a/dotfiles/.default-npm-packages
+++ b/dotfiles/.default-npm-packages
@@ -1,10 +1,2 @@
 dialogflow
-@google-cloud/bigquery-storage
-@google-cloud/compute
-@google-cloud/cloudbuild
-@google-cloud/monitoring
-@google-cloud/pubsub
-@google-cloud/scheduler
-@google-cloud/spanner
-@google-cloud/storage
 vercel

--- a/scripts/setup-shell.bash
+++ b/scripts/setup-shell.bash
@@ -61,8 +61,8 @@ else
 fi
 
 # add fonts for powerline
-# WARN: I have had issues with "fc-list | grep" on WSL2. The temp solution is toggle the comments of "installed_fonts" lines
-# installed_fonts=""
+# WARN: I have had issues with "fc-list | grep" on Ubuntu (native and WSL2). The temp solution is toggle the comments of "installed_fonts" lines
+installed_fonts=""
 # installed_fonts=$(fc-list : file family | grep --ignore-case "powerline")
 if [ -n "$installed_fonts" ]; then
 	log_success "Powerline fonts already installed"

--- a/scripts/setup-shell.bash
+++ b/scripts/setup-shell.bash
@@ -63,7 +63,7 @@ fi
 # add fonts for powerline
 # WARN: I have had issues with "fc-list | grep" on WSL2. The temp solution is toggle the comments of "installed_fonts" lines
 # installed_fonts=""
-installed_fonts=$(fc-list : file family | grep --ignore-case "powerline")
+# installed_fonts=$(fc-list : file family | grep --ignore-case "powerline")
 if [ -n "$installed_fonts" ]; then
 	log_success "Powerline fonts already installed"
 else


### PR DESCRIPTION
- remove `asdf java` from default installation
- improve instructions for installing `devtools`
- remove VSCode ext Settings Sync recommendation as it is a built-in feature now
- remove `@google-cloud/*` npm packages as default nodejs installations
- comment out `installed_fonts` `fc-list` command as it fails in both Ubuntu on WSL2 and native Ubuntu