### PR TITLE
refactor: remove regolith config

### DIFF
--- a/dotfiles/.config/regolith/Xresources
+++ b/dotfiles/.config/regolith/Xresources
@@ -1,1 +1,0 @@
-i3-wm.bar.position: top


### PR DESCRIPTION
I have moved from using [Regolith (i3wm on Ubuntu)](https://regolith-linux.org/) to [PopOS](https://pop.system76.com/) as they introduced a tiling wm solution to Gnome. The tiling is young, but enough to replace i3 for my use cases and requires fewer modifications.