### PR TITLE
refactor: install asdf plugins by urls

### DIFF
--- a/config/initial-asdf-plugins.txt
+++ b/config/initial-asdf-plugins.txt
@@ -1,10 +1,10 @@
-firebase latest
-golang latest
-hadolint v1.17.5
-nodejs 14.8.0
-python latest
-shellcheck latest
-shfmt latest
-terraform latest
-gcloud latest
-deno latest
+deno https://github.com/asdf-community/asdf-deno.git latest
+firebase https://github.com/jthegedus/asdf-firebase.git latest
+gcloud https://github.com/jthegedus/asdf-gcloud.git latest
+golang https://github.com/kennyp/asdf-golang.git latest
+hadolint https://github.com/looztra/asdf-hadolint.git v1.22.1
+nodejs https://github.com/asdf-vm/asdf-nodejs.git 14.15.5
+python https://github.com/danhper/asdf-python.git latest
+shellcheck https://github.com/luizm/asdf-shellcheck.git latest
+shfmt https://github.com/luizm/asdf-shfmt.git latest
+terraform https://github.com/Banno/asdf-hashicorp.git latest

--- a/scripts/setup-devtools.bash
+++ b/scripts/setup-devtools.bash
@@ -7,7 +7,8 @@ source "$(dirname "$0")/utils.bash"
 
 function asdf_plugin_setup() {
 	local plugin_name="${1}"
-	local plugin_version="${2}"
+	local plugin_url="${2}"
+	local plugin_version="${3}"
 
 	log_info "Installing ${plugin_name} via asdf"
 
@@ -41,7 +42,7 @@ function asdf_plugin_setup() {
 		fi
 	fi
 
-	asdf plugin add "${plugin_name}" || true
+	asdf plugin add "${plugin_name}" "${plugin_url}" || true
 	# TODO: fix so a more precise check of output is performed
 	#
 	# status_code=$(asdf plugin add "${plugin_name}")
@@ -82,8 +83,9 @@ initial_asdf_plugin_list="$(dirname "$(dirname "$0")")/config/initial-asdf-plugi
 if [ -f "$initial_asdf_plugin_list" ]; then
 	while read -r p || [ -n "$p" ]; do
 		plugin_name="$(cut -d ' ' -f1 <<<"$p")"
-		plugin_version="$(cut -d ' ' -f2 <<<"$p")"
-		asdf_plugin_setup "$plugin_name" "$plugin_version"
+		plugin_url="$(cut -d ' ' -f2 <<<"$p")"
+		plugin_version="$(cut -d ' ' -f3 <<<"$p")"
+		asdf_plugin_setup "$plugin_name" "$plugin_url" "$plugin_version"
 	done <"$initial_asdf_plugin_list"
 fi
 


### PR DESCRIPTION
Install `asdf` plugins by URL instead of the asdf-plugins cache/index.

Closes #55 